### PR TITLE
Fix too many requests

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -62,6 +62,9 @@ dependencies {
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
 
   testImplementation 'com.mockrunner:mockrunner-servlet:2.0.1'
+
+  // A general-purpose mocking library
+  testImplementation 'org.mockito:mockito-core:2.28.2'
 }
 
 application {

--- a/server/src/main/java/umm3601/TokenVerifier.java
+++ b/server/src/main/java/umm3601/TokenVerifier.java
@@ -10,6 +10,7 @@ import com.auth0.jwk.UrlJwkProvider;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.github.kevinsawicki.http.HttpRequest;
@@ -49,6 +50,21 @@ public class TokenVerifier {
     }
 
     return false;
+  }
+
+  public String getSubFromToken(Context ctx) {
+    String token = ctx.header("Authorization").replace("Bearer ", "");
+    String tokenAsString = null;
+
+    try {
+      DecodedJWT jwt = JWT.decode(token);
+      tokenAsString = jwt.getSubject();
+    } catch (JWTDecodeException e) {
+      ctx.status(400);
+      e.printStackTrace();
+    }
+
+    return tokenAsString;
   }
 
   public String getUserInfo(Context ctx) {

--- a/server/src/main/java/umm3601/TokenVerifier.java
+++ b/server/src/main/java/umm3601/TokenVerifier.java
@@ -23,8 +23,14 @@ public class TokenVerifier {
   public TokenVerifier() {
   }
 
-  // https://community.auth0.com/t/verify-jwt-token-received-from-auth0/35581/4
-  public boolean verifyToken(Context ctx) throws InterruptedException {
+  /**
+   * Given a context containing an Access JWT, verify said token
+   * Based on the code from https://community.auth0.com/t/verify-jwt-token-received-from-auth0/35581/4
+   * @param ctx the context containing the JWT
+   * @return true if the token is successfully verified
+   * Sets context status to 400 if there is an error
+   */
+  public boolean verifyToken(Context ctx) {
     String token = ctx.header("Authorization").replace("Bearer ", "");
     JwkProvider provider = new UrlJwkProvider("https://dev-h60mw6th.auth0.com/");
     try {
@@ -52,6 +58,12 @@ public class TokenVerifier {
     return false;
   }
 
+  /**
+   * Retrieve the subject from a context containing an Access JWT
+   * Note: The method assumes that the context has been verified
+   * @param ctx the context containing the JWT
+   * @return the subject of the JWT as a string
+   */
   public String getSubFromToken(Context ctx) {
     String token = ctx.header("Authorization").replace("Bearer ", "");
     String tokenAsString = null;
@@ -67,6 +79,11 @@ public class TokenVerifier {
     return tokenAsString;
   }
 
+  /**
+   * Calls Auth0 to get a user's info
+   * @param ctx a context containing an Access JWT given to the user who's info is desired
+   * @return the info as a string
+   */
   public String getUserInfo(Context ctx) {
     String token = ctx.header("Authorization");
 
@@ -75,6 +92,11 @@ public class TokenVerifier {
     return userInfo;
   }
 
+  /**
+   * Parses out the nickname from a given user's info
+   * @param userInfo the user's info as a string
+   * @return the user's x500 as a string
+   */
   public String getNewOwnerx500(String userInfo) {
 
     // Pull the x500 out of the body, there's definitely a better way to do this, but idk how
@@ -91,6 +113,11 @@ public class TokenVerifier {
     return x500;
   }
 
+  /**
+   * Parses out the subject from a given user's info
+   * @param userInfo the user's info as a string
+   * @return the sub as a string
+   */
   public String getNewOwnerSub(String userInfo) {
 
     System.err.println(userInfo);

--- a/server/src/main/java/umm3601/TokenVerifier.java
+++ b/server/src/main/java/umm3601/TokenVerifier.java
@@ -35,7 +35,7 @@ public class TokenVerifier {
       JWTVerifier verifier = JWT.require(algorithm).withIssuer("https://dev-h60mw6th.auth0.com/").acceptLeeway(1).build();
 
       jwt = verifier.verify(token);
-      
+
 
       return true;
 
@@ -66,7 +66,28 @@ public class TokenVerifier {
     int endIndex = temp.indexOf('"');
     System.err.println(endIndex);
     String x500 = temp.substring(0, endIndex);
+    System.err.println(x500);
 
     return x500;
+  }
+
+  public String getNewOwnerSub(Context ctx) {
+
+    String token = ctx.header("Authorization");
+
+    String userInfo = HttpRequest.get("https://dev-h60mw6th.auth0.com/userinfo").authorization(token).body();
+
+    // Pull the x500 out of the body, there's definitely a better way to do this, but idk how
+    System.err.println(userInfo);
+    int startIndex = userInfo.indexOf("\"sub\":\"");
+    System.err.println(startIndex);
+    String temp = userInfo.substring(startIndex + 7);
+    System.err.println(temp);
+    int endIndex = temp.indexOf('"');
+    System.err.println(endIndex);
+    String sub = temp.substring(0, endIndex);
+    System.err.println(sub);
+
+    return sub;
   }
 }

--- a/server/src/main/java/umm3601/TokenVerifier.java
+++ b/server/src/main/java/umm3601/TokenVerifier.java
@@ -51,11 +51,15 @@ public class TokenVerifier {
     return false;
   }
 
-  public String getOwnerx500(Context ctx) {
-
+  public String getUserInfo(Context ctx) {
     String token = ctx.header("Authorization");
 
     String userInfo = HttpRequest.get("https://dev-h60mw6th.auth0.com/userinfo").authorization(token).body();
+
+    return userInfo;
+  }
+
+  public String getNewOwnerx500(String userInfo) {
 
     // Pull the x500 out of the body, there's definitely a better way to do this, but idk how
     System.err.println(userInfo);
@@ -71,13 +75,8 @@ public class TokenVerifier {
     return x500;
   }
 
-  public String getNewOwnerSub(Context ctx) {
+  public String getNewOwnerSub(String userInfo) {
 
-    String token = ctx.header("Authorization");
-
-    String userInfo = HttpRequest.get("https://dev-h60mw6th.auth0.com/userinfo").authorization(token).body();
-
-    // Pull the x500 out of the body, there's definitely a better way to do this, but idk how
     System.err.println(userInfo);
     int startIndex = userInfo.indexOf("\"sub\":\"");
     System.err.println(startIndex);

--- a/server/src/main/java/umm3601/notes/NoteController.java
+++ b/server/src/main/java/umm3601/notes/NoteController.java
@@ -59,8 +59,8 @@ public class NoteController {
   }
 
   public void checkOwnerForNewNote(Context ctx) {
-    String x500 = tokenVerifier.getOwnerx500(ctx);
-    String ownerID = ownerController.getOwnerIDByx500(x500);
+    String sub = tokenVerifier.getSubFromToken(ctx);
+    String ownerID = ownerController.getOwnerIDBySub(sub);
 
     Note newNote = ctx.bodyAsClass(Note.class);
 
@@ -71,8 +71,8 @@ public class NoteController {
   }
 
   public void checkOwnerForGivenNote(Context ctx) {
-    String x500 = tokenVerifier.getOwnerx500(ctx);
-    String ownerID = ownerController.getOwnerIDByx500(x500);
+    String sub = tokenVerifier.getSubFromToken(ctx);
+    String ownerID = ownerController.getOwnerIDBySub(sub);
 
     String noteID = ctx.pathParam("id");
     Note note;

--- a/server/src/main/java/umm3601/owners/Owner.java
+++ b/server/src/main/java/umm3601/owners/Owner.java
@@ -12,5 +12,6 @@ public class Owner {
   public String email;
   public String building;
   public String x500;
+  public String sub;
 
 }

--- a/server/src/main/java/umm3601/owners/OwnerController.java
+++ b/server/src/main/java/umm3601/owners/OwnerController.java
@@ -116,4 +116,20 @@ public class OwnerController {
       return owner._id;
     }
   }
+
+  public String getOwnerIDBySub(String sub) {
+    Owner owner;
+
+    try {
+      owner = ownerCollection.find(eq("sub", sub)).first();
+    } catch(IllegalArgumentException e) {
+      throw new BadRequestResponse("The requested owner sub wasn't a legal Mongo Object.");
+    }
+
+    if(owner== null) {
+      throw new NotFoundResponse("The requested owner was not found");
+    } else {
+      return owner._id;
+    }
+  }
 }

--- a/server/src/main/java/umm3601/owners/OwnerController.java
+++ b/server/src/main/java/umm3601/owners/OwnerController.java
@@ -91,6 +91,10 @@ public class OwnerController {
     Owner newOwner = ctx.bodyValidator(Owner.class)
     .check((owner) -> owner.name.length() >= 2 && owner.name.length() <= 300).get();
 
+    String userInfo = tokenVerifier.getUserInfo(ctx);
+    String ownerSub = tokenVerifier.getNewOwnerSub(userInfo);
+    newOwner.sub = ownerSub;
+
     ownerCollection.insertOne(newOwner);
     ctx.status(201);
     ctx.json(ImmutableMap.of("id", newOwner._id));

--- a/server/src/main/java/umm3601/owners/OwnerController.java
+++ b/server/src/main/java/umm3601/owners/OwnerController.java
@@ -28,17 +28,21 @@ public class OwnerController {
   JacksonCodecRegistry jacksonCodecRegistry = JacksonCodecRegistry.withDefaultObjectMapper();
 
   private final MongoCollection<Owner> ownerCollection;
-  private final TokenVerifier tokenVerifier;
+  public final TokenVerifier tokenVerifier;
 
   public static final String DELETED_RESPONSE = "deleted";
   public static final String NOT_DELETED_RESPONSE = "nothing deleted";
 
   public OwnerController(MongoDatabase database) {
+    this(database, new TokenVerifier());
+  }
+
+  public OwnerController(MongoDatabase database, TokenVerifier tokenVerifier) {
     jacksonCodecRegistry.addCodecForClass(Owner.class);
     ownerCollection = database.getCollection("owners").withDocumentClass(Owner.class)
         .withCodecRegistry(jacksonCodecRegistry);
 
-    tokenVerifier = new TokenVerifier();
+    this.tokenVerifier = tokenVerifier;
   }
 
   public boolean verifyHttpRequest(Context ctx) throws Exception {


### PR DESCRIPTION
This aims to fix the issue where the server would start throwing errors after a user attempts to do too many actions within a minute.

Instead of sending an http request to Auth0 every time a change is made to a users notes, one is only sent the first time a user logs in. After that the subject identifier that Auth0 uses in the JWTs is stored for each user.